### PR TITLE
Update M5Stack PbHub to work with ESPHome 2025.2 GPIOPin get_flags

### DIFF
--- a/components/m5stack_pbhub/m5stack_pbhub.h
+++ b/components/m5stack_pbhub/m5stack_pbhub.h
@@ -57,6 +57,8 @@ class PBHUBGPIOPin : public GPIOPin {
   void set_inverted(bool inverted) { inverted_ = inverted; }
   void set_flags(gpio::Flags flags) { flags_ = flags; }
 
+  gpio::Flags get_flags() const override { return this->flags_; }
+
  protected:
   M5StackPBHUBComponent *parent_;
   uint8_t pin_;


### PR DESCRIPTION
Addresses [#8151](https://github.com/esphome/esphome/pull/8151) as suggested in #17.  This allows ESPHome configuration to compile with this external component on 2025.2.  Closes #17.