### PR TITLE
Fix variable reference in ultrasonic distance sensor code

### DIFF
--- a/Ultrasonic Distance Unit I2C (RCWL-9620).md
+++ b/Ultrasonic Distance Unit I2C (RCWL-9620).md
@@ -47,7 +47,7 @@ sensor:
    icon: "mdi:waves"
    update_interval: 10s # Or whatever update interval you prefer
    lambda: |-
-    auto x = id(ultrasonic_gr1_res).state;
+    auto x = id(ultrasonic1).state;
     const float min_distance = 190.0;
     const float max_distance = 880.0;
     if (isnan(x)) {


### PR DESCRIPTION
Fixed the reference to id `ultrasonic1`. The ESPHome validation flagged this when I used this code today to set up my ultrasonic sensor. Tested and working.

Thanks again for providing all these samples.